### PR TITLE
Backport upstream patch to use `SO_REUSEPORT` optionally

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -26,14 +26,6 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 source run_conda_forge_build_setup
 
-
-# Install the yum requirements defined canonically in the
-# "recipe/yum_requirements.txt" file. After updating that file,
-# run "conda smithy rerender" and this line will be updated
-# automatically.
-/usr/bin/sudo -n yum install -y kernel-headers
-
-
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,18 +1,4 @@
 #!/bin/bash
 
-################################################
-# Use `asm-generic/socket.h` from distro.      #
-# Needed to ensure `SO_REUSEPORT` is defined.  #
-# This feature was added in Linux kernel 3.9.  #
-# However RHEL 6 and CentOS 6 backported it.   #
-# The sysroot compilers get in the way so we   #
-# use this header from this system to define   #
-# `SO_REUSEPORT`.                              #
-#                                              #
-# ref: https://lwn.net/Articles/542629/        #
-################################################
-CONDA_BUILD_SYSROOT="$(${CC} --print-sysroot)"
-cp /usr/include/asm-generic/socket.h "${CONDA_BUILD_SYSROOT}/usr/include/asm-generic/socket.h"
-
 make -j${CPU_COUNT} CUDA_HOME="${CUDA_HOME}" CUDARTLIB="cudart"
 make install PREFIX="${PREFIX}"

--- a/recipe/commit_7f2b337.patch
+++ b/recipe/commit_7f2b337.patch
@@ -1,0 +1,32 @@
+From 7f2b337e703d73ed369937c9996e1f3d5f664ad0 Mon Sep 17 00:00:00 2001
+From: David Addison <daddison@nvidia.com>
+Date: Tue, 13 Aug 2019 16:32:07 -0700
+Subject: [PATCH] Make use of SO_REUSEPORT conditional
+
+Fixes: #244
+
+SO_RESUEPORT was introduced in Linux 3.9 and later.
+This change allows NCCL to compile against older releases.
+
+The functionality is only required if the user is specifying
+a NCCL bootstrap address via an environment variable.
+---
+ src/include/socket.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/include/socket.h b/src/include/socket.h
+index 68ce235d6..b4f09b9cc 100644
+--- a/src/include/socket.h
++++ b/src/include/socket.h
+@@ -327,7 +327,11 @@ static ncclResult_t createListenSocket(int *fd, union socketAddress *localAddr)
+   if (socketToPort(&localAddr->sa)) {
+     // Port is forced by env. Make sure we get the port.
+     int opt = 1;
++#if defined(SO_REUSEPORT)
+     SYSCHECK(setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt)), "setsockopt");
++#else
++    SYSCHECK(setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)), "setsockopt");
++#endif
+   }
+ 
+   // localAddr port should be 0 (Any port)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,13 @@ package:
 source:
   url: https://github.com/NVIDIA/nccl/archive/v{{ version }}-{{ revision }}.tar.gz
   sha256: e2260da448ebbebe437f74768a346d28c74eabdb92e372a3dc6652a626318924
+  patches:
+    #########################################################
+    # Only uses `SO_REUSEPORT` if defined at compile time.  #
+    #                                                       #
+    # xref: https://github.com/NVIDIA/nccl/commit/7f2b337   #
+    #########################################################
+    - commit_7f2b337.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - commit_7f2b337.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [(not linux64) or (cuda_compiler_version == "None")]
   run_exports:
     # xref: https://github.com/NVIDIA/nccl/issues/218

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,1 +1,0 @@
-kernel-headers


### PR DESCRIPTION
This uses commit ( https://github.com/NVIDIA/nccl/commit/7f2b337e703d73ed369937c9996e1f3d5f664ad0 ) to backport a patch to only use `SO_REUSEPORT` optionally. By doing this, we are able to drop the workaround of using the kernel header, `asm-generic/socket.h`, from the system (instead of the conda compilers).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/nccl-feedstock/issues/1

<!--
Please add any other relevant info below:
-->
