### PR TITLE
Merge `revision` into `version`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,12 @@
 {% set name = "nccl" %}
-{% set version = "2.5.6" %}
-{% set revision = "1" %}
+{% set version = "2.5.6-1" %}
 
 package:
   name: {{ name|lower }}
-  version: {{ version }}.{{ revision }}
+  version: {{ version|replace("-", ".") }}
 
 source:
-  url: https://github.com/NVIDIA/nccl/archive/v{{ version }}-{{ revision }}.tar.gz
+  url: https://github.com/NVIDIA/nccl/archive/v{{ version }}.tar.gz
   sha256: 38a37d98be11f43232b988719226866b407f08b9666dcaf345796bd8f354ef54
 
 build:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/nccl-feedstock/issues/14

Should make it easier for the autoupdate bot to pick up new versions.

cc @CJ-Wright

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
