### PR TITLE
Only use `cuda-version` (not `cudatoolkit`)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-Allow-custom-NVCC-path.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [(not linux) or cuda_compiler_version in (undefined, "None", "10.2")]
   ignore_run_exports_from:
     # Ignore `cudatoolkit` dependency in CUDA 11 builds

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,9 @@ source:
 build:
   number: 0
   skip: true  # [(not linux) or cuda_compiler_version in (undefined, "None", "10.2")]
+  ignore_run_exports_from:
+    # Ignore `cudatoolkit` dependency in CUDA 11 builds
+    - {{ compiler("cuda") }}  # [(cuda_compiler_version or "").startswith("11")]
   run_exports:
     # xref: https://github.com/NVIDIA/nccl/issues/218
     - {{ pin_subpackage(name, max_pin="x") }}
@@ -25,6 +28,10 @@ requirements:
     - {{ compiler("cxx") }}
     - {{ compiler("cuda") }}
     - make
+  host:
+    - cuda-version ={{ cuda_compiler_version }}          # [(cuda_compiler_version or "").startswith("11")]
+  run:
+    - {{ pin_compatible("cuda-version", max_pin="x") }}  # [(cuda_compiler_version or "").startswith("11")]
 
 test:
   commands:


### PR DESCRIPTION
Drop the `cudatoolkit` dependency from `nccl` on CUDA 11. Instead just use `cuda-version` (as is used on CUDA 12). Since `nccl` doesn't appear to have any dynamic linkages to CTK libraries, this shouldn't present any issues. Will also simplify and lighten the install of `nccl` for users. As `cuda-version` constrains `cudatoolkit`, users trying to constrain the `nccl` package installed by specifying the `cudatoolkit` version to install should still see the expected behavior.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
