### PR TITLE
Apply shellcheck fixes, extend testing & some minor refreshing

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,12 +31,12 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
+mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
+echo > /opt/conda/conda-meta/history
+micromamba install --root-prefix ~/.conda --prefix /opt/conda \
+    --yes --override-channels --channel conda-forge --strict-channel-priority \
+    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
-
-mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
-mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -48,9 +48,6 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
-fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -12,7 +12,7 @@ github:
   branch_name: main
   tooling_branch_name: main
 os_version:
-  linux_64: cos6
+  linux_64: cos7
   linux_aarch64: cos7
   linux_ppc64le: cos7
 provider:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -19,4 +19,3 @@ os_version:
 provider:
   linux_aarch64: default
   linux_ppc64le: default
-test: native_and_emulated

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -16,6 +16,6 @@ os_version:
   linux_aarch64: cos7
   linux_ppc64le: cos7
 provider:
-  linux_aarch64: azure
-  linux_ppc64le: azure
+  linux_aarch64: default
+  linux_ppc64le: default
 test: native_and_emulated

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,6 +6,7 @@ build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64
 conda_build:
+  error_overlinking: true
   pkg_format: '2'
 conda_forge_output_validation: true
 github:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
 if [[ "${cuda_compiler_version}" =~ 12.* ]]; then
-  export CUDA_HOME=${BUILD_PREFIX}
+  export CUDA_HOME="${BUILD_PREFIX}"
 elif [[ "${cuda_compiler_version}" != "None" ]]; then
-  export CUDA_HOME=${CUDA_PATH}
+  export CUDA_HOME="${CUDA_PATH}"
 fi
 
-if [[ $CONDA_BUILD_CROSS_COMPILATION == "1" ]]; then
-    if [[ $target_platform == linux-aarch64 ]]; then
-        export CUDA_LIB=${CUDA_HOME}/targets/sbsa-linux/lib/
-    elif [[ $target_platform == linux-ppc64le ]]; then
-        export CUDA_LIB=${CUDA_HOME}/targets/ppc64le-linux/lib/
+if [[ "${CONDA_BUILD_CROSS_COMPILATION}" == "1" ]]; then
+    if [[ "${target_platform}" == "linux-aarch64" ]]; then
+        export CUDA_LIB="${CUDA_HOME}/targets/sbsa-linux/lib/"
+    elif [[ "${target_platform}" == "linux-ppc64le" ]]; then
+        export CUDA_LIB="${CUDA_HOME}/targets/ppc64le-linux/lib/"
     else
         echo "not supported"
-        exit -1
+        exit 1
     fi
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,7 @@
 if [[ -z "${CUDA_HOME+x}" ]]; then
   # `$CUDA_HOME` was set for CUDA 11.x and earlier.
   # Must be using CUDA 12.0+. So set to `$BUILD_PREFIX`.
+  # This is needed to find `nvcc` and `cudart`.
   export CUDA_HOME="${BUILD_PREFIX}"
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-if [[ "${cuda_compiler_version}" =~ 12.* ]]; then
+if [[ -z "${CUDA_HOME+x}" ]]; then
+  # `$CUDA_HOME` was set for CUDA 11.x and earlier.
+  # Must be using CUDA 12.0+. So set to `$BUILD_PREFIX`.
   export CUDA_HOME="${BUILD_PREFIX}"
-elif [[ "${cuda_compiler_version}" != "None" ]]; then
-  export CUDA_HOME="${CUDA_PATH}"
 fi
 
 if [[ "${CONDA_BUILD_CROSS_COMPILATION}" == "1" ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,8 @@ build:
 
 requirements:
   build:
-    - {{ compiler("c") }}
     - {{ stdlib("c") }}
+    - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - {{ compiler("cuda") }}
     - make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-use-conda-ar-not-system.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [(not linux) or cuda_compiler_version in (undefined, "None", "10.2")]
   ignore_run_exports_from:
     # Ignore `cudatoolkit` dependency in CUDA 11 builds


### PR DESCRIPTION
* Enable overlinking check (ensure `cudart` was statically linked or error if not)
* Always run package tests (these work even when cross-compiled or emulated so always run them)
* Fix outdated reference to CentOS 6 (conda-forge [moved to CentOS 7]( https://conda-forge.org/news/2023/07/12/end-of-life-for-centos-6/ ))
* Apply shellcheck fixes (quoting environment variables, use `exit 1`, etc.)
* Simplify `CUDA_HOME` assignment for CUDA 12.0+ (already defined in CUDA 11.x and earlier)
* Some other minor cleanup

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
