### PR TITLE
Update for NCCL 2.30.3

### DIFF
--- a/.ci_support/linux_64_cuda_compiler_version12.9.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version12.9.yaml
@@ -10,10 +10,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-clang_compiler:
-- clang
-clang_compiler_version:
-- '21'
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:

--- a/.ci_support/linux_64_cuda_compiler_version13.2.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version13.2.yaml
@@ -10,14 +10,10 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-clang_compiler:
-- clang
-clang_compiler_version:
-- '21'
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '13.1'
+- '13.2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_aarch64_arm_variant_typesbsac_stdlib_version2.28cuda_compiler_version12.9.yaml
+++ b/.ci_support/linux_aarch64_arm_variant_typesbsac_stdlib_version2.28cuda_compiler_version12.9.yaml
@@ -12,10 +12,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-clang_compiler:
-- clang
-clang_compiler_version:
-- '21'
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:

--- a/.ci_support/linux_aarch64_arm_variant_typesbsac_stdlib_version2.28cuda_compiler_version13.2.yaml
+++ b/.ci_support/linux_aarch64_arm_variant_typesbsac_stdlib_version2.28cuda_compiler_version13.2.yaml
@@ -12,14 +12,10 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-clang_compiler:
-- clang
-clang_compiler_version:
-- '21'
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '13.1'
+- '13.2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_aarch64_arm_variant_typetegrac_stdlib_version2.34cuda_compiler_version12.9.yaml
+++ b/.ci_support/linux_aarch64_arm_variant_typetegrac_stdlib_version2.34cuda_compiler_version12.9.yaml
@@ -12,10 +12,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-clang_compiler:
-- clang
-clang_compiler_version:
-- '21'
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:

--- a/.ci_support/migrations/cuda13x.yaml
+++ b/.ci_support/migrations/cuda13x.yaml
@@ -5,7 +5,7 @@ __migrator:
     1
   build_number:
     1
-  paused: false
+  paused: true
   use_local: true
   override_cbc_keys:
     - cuda_compiler_stub
@@ -20,6 +20,7 @@ __migrator:
       - 12.9
       - 13.0
       - 13.1
+      - 13.2
       # to allow manual opt-in for CUDA 11.8, see
       # https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7472
       # must be last due to how cuda_compiler ordering in that migrator works
@@ -49,7 +50,7 @@ __migrator:
     > might be replaced with `# [cuda_compiler_version != "None"]`.
 
 cuda_compiler_version:         # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
-  - 13.1                       # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 13.2                       # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 
 c_stdlib_version:              # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
   - 2.28                       # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -27,7 +27,7 @@ jobs:
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-          - CONFIG: linux_64_cuda_compiler_version13.1
+          - CONFIG: linux_64_cuda_compiler_version13.2
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -37,7 +37,7 @@ jobs:
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-          - CONFIG: linux_aarch64_arm_variant_typesbsac_stdlib_version2.28cuda_compiler_version13.1
+          - CONFIG: linux_aarch64_arm_variant_typesbsac_stdlib_version2.28cuda_compiler_version13.2
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -35,13 +35,6 @@ if [[ "${CONDA_BUILD_CROSS_COMPILATION}" == "1" ]]; then
     fi
 fi
 
-# For now, we emit LLVM IR for CUDA 12.x only.
-if [[ "${cuda_compiler_version}" == 12.* ]]; then
-    EMIT_LLVM_IR=1
-else
-    EMIT_LLVM_IR=0
-fi
-
 # NCCL's Makefile assumes a standard system-wide CUDA installation where
 # everything lives under one directory (e.g. /usr/local/cuda/include,
 # /usr/local/cuda/bin/nvcc, etc.). Conda does not install CUDA that way.
@@ -66,7 +59,7 @@ CUDA_INC="$BUILD_PREFIX/$targetsDir/include"
 # build env. Listing it as a build: dependency breaks cross-compilation for linux-aarch64
 touch "$BUILD_PREFIX/$targetsDir/include/curand_mtgp32_kernel.h"
 
-make -j1 pkg.txz.build EMIT_LLVM_IR="$EMIT_LLVM_IR" \
+make -j1 pkg.txz.build EMIT_LLVM_IR=1 \
   CUDA_HOME="$BUILD_PREFIX" \
   CUDA_INC="$CUDA_INC" \
   NVCC="$BUILD_PREFIX/bin/nvcc"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "nccl" %}
-{% set version = "2.29.7-1" %}
+{% set version = "2.30.3-1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/NVIDIA/nccl/archive/v{{ version }}.tar.gz
-  sha256: e67239212c395bfdb398a7519491840d06fdf6b599c299f97c7ed0109777bba1
+  sha256: e86c3d653ace400f8b7dd0a41ca7443fbd1392ac0b02895faf1185c44af75397
   patches:
     - 0001-use-conda-ar-not-system.patch
 
@@ -25,10 +25,11 @@ requirements:
   build:
     - {{ stdlib("c") }}
     - {{ compiler("c") }}
-    - {{ compiler("clang") }}  # [(cuda_compiler_version or "").startswith("12")]
     - {{ compiler("cxx") }}
     - {{ compiler("cuda") }}
     - arm-variant * {{ arm_variant_type }}  # [linux and aarch64 and cuda_compiler_version != "None"]
+    - clang 21.*  # [(cuda_compiler_version or "").startswith("12")]
+    - clang 22.*  # [(cuda_compiler_version or "").startswith("13")]
     - llvm-tools
     - make
   host:
@@ -39,9 +40,9 @@ requirements:
 test:
   commands:
     - test -f "${PREFIX}/include/nccl.h"
-    - test -f "${PREFIX}/include/nccl_device_wrapper.h"  # [(cuda_compiler_version or "").startswith("12")]
+    - test -f "${PREFIX}/include/nccl_device_wrapper.h"
     - test -f "${PREFIX}/lib/libnccl.so"
-    - test -f "${PREFIX}/lib/libnccl_device.bc"          # [(cuda_compiler_version or "").startswith("12")]
+    - test -f "${PREFIX}/lib/libnccl_device.bc"
     - test ! -f "${PREFIX}/lib/libnccl_static.a"
 
 about:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Here I am listing clang version explicitly and not through migrators for cuda12 and cuda 13. I spent hours talking with AI trying to get to work but failed because clang `21` was applied even for cuda 13. It seems one could add one clang version that is applied across the board and cannot be controlled per cuda version. This may be due to the fact that clang is not part of global pinning's `zip_keys` set. Adding `clang_compiler_version` to the `zip_keys` in my local migrators created even messier failures during rerendering. 

<!--
Please add any other relevant info below:
-->
